### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ automatically enforce policies that ensure that every piece of infrastructure
 that developers provision is made compliant with the organization's policies,
 without requiring additional effort on the part of developers.
 
-Using Scalr, this is be achieved through the enforcement of specific cloud
+Using Scalr, this is achieved through the enforcement of specific cloud
 configurations (e.g. VPC, with Governance), the definition of user-level
 restrictions (Role-Based Access Control), the execution of host-level
 compliance scripts (Global Orchestration), and integration with external


### PR DESCRIPTION
Chose "this is achieved" over "this can be achieved" to remove ambiguity that there are multiple ways in Scalr to do this, and to show more confidence in what we state.
